### PR TITLE
Update log_processor.py

### DIFF
--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -377,12 +377,11 @@ class LogProcessor:
                 tag[key] = mode_history_scalars[key].current()
         # Update custom keys.
         for log_cfg in custom_cfg:
-            if not reserve_prefix:
-                data_src = log_cfg.pop('data_src')
-                log_name = f"{log_cfg.pop('log_name', data_src)}"
-            else:
-                data_src = f"{mode}/{log_cfg.pop('data_src')}"
-                log_name = f"{mode}/{log_cfg.pop('log_name', data_src)}"
+            data_src = log_cfg.pop('data_src')
+            log_name = f"{log_cfg.pop('log_name', data_src)}"
+            if reserve_prefix:
+                data_src = f"{mode}/{data_src}"
+                log_name = f"{mode}/{log_name}"
             # log item in custom_cfg could only exist in train or val
             # mode.
             if data_src in mode_history_scalars:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When `log_with_hierarchy` is set to True, the keyword `mode` appears nested multiple times in the log. For example, val/val/data_time: 0.0332 val/val/time: 0.4490.
<img width="914" alt="bug_val" src="https://github.com/huaibovip/mmengine/assets/53330216/971aea73-86f1-495c-9158-cf8ef4cc61ad">


## Modification
https://github.com/open-mmlab/mmengine/blob/a483dba9d15308f9442e87faf80c1d7279137519/mmengine/runner/log_processor.py#L379
```
        for log_cfg in custom_cfg:
            if not reserve_prefix:
                data_src = log_cfg.pop('data_src')
                log_name = f"{log_cfg.pop('log_name', data_src)}"
            else:
                data_src = f"{mode}/{log_cfg.pop('data_src')}"
                log_name = f"{mode}/{log_cfg.pop('log_name', data_src)}"
```   
to
```
        for log_cfg in custom_cfg:
            data_src = log_cfg.pop('data_src')
            log_name = f"{log_cfg.pop('log_name', data_src)}"
            if reserve_prefix:
                data_src = f"{mode}/{data_src}"
                log_name = f"{mode}/{log_name}"
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
